### PR TITLE
Feat: Display keyboard shortcuts in UI

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -60,6 +60,20 @@
             <h2>Backend Info</h2>
             <div class="info-section"><h3>Org Paths:</h3><ul id="org-paths-list"></ul></div>
             <div class="info-section"><h3>Global Tags:</h3><ul id="global-tags-list"></ul></div>
+            <div class="info-section">
+                <h3>Keyboard Shortcuts:</h3>
+                <ul id="keyboard-shortcuts-list" style="font-size: 0.9em; padding-left: 15px;">
+                    <li><strong>X + Left-click (on photo):</strong> View original photo.</li>
+                    <li><strong>T + Left-click (on photo):</strong> Apply active tags to photo.</li>
+                    <li><strong>D + Left-click (on displayed tag):</strong> Remove specific tag from photo.</li>
+                    <li><strong>In Photo Viewer:</strong>
+                        <ul style="padding-left: 15px; margin-top: 3px;">
+                            <li><strong>← / → (Arrow Keys):</strong> Previous/Next photo.</li>
+                            <li><strong>ESC Key:</strong> Close viewer.</li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
         </aside>
     </div>
 


### PR DESCRIPTION
Added a 'Keyboard Shortcuts' section to the 'Backend Info' panel in `templates/index.html`.

This section lists the available keyboard shortcuts to improve user discoverability and ease of use, including:
- X + Left-click: View original photo.
- T + Left-click: Apply active tags.
- D + Left-click on tag: Remove specific tag.
- Arrow keys & ESC in photo viewer.

This is a static informational update to the UI.